### PR TITLE
Update ActorDetails.swift

### DIFF
--- a/Shared/Models/ActorDetails.swift
+++ b/Shared/Models/ActorDetails.swift
@@ -20,6 +20,7 @@ struct Cast: Codable,Identifiable {
     let profilePath: String?
     
     public var ProfilePathUrl: URL {
+        
         return URL(string: "https://image.tmdb.org/t/p/w500\(profilePath ?? "")") ?? URL(string: "https://www.pexels.com/photo/person-holding-photo-of-single-tree-at-daytime-1252983/")!
     }
 }


### PR DESCRIPTION
Don't Include URL Dependency to a struct consider passing the URL through the initializer in order to enable the testability